### PR TITLE
Inicio tests clase generatedQuestionList + aumento tests ranking + edit generacion preguntas y respuestas no genere Q12345 + nuevas queries + funcionalidad elim primera pregunta generada

### DIFF
--- a/gatewayservice/gateway-service.js
+++ b/gatewayservice/gateway-service.js
@@ -303,6 +303,20 @@ app.delete('/deleteAllQuestionTest', async (req, res) => {
   }
 });
 
+// Ruta para eliminar todas las preguntas de prueba
+app.delete('/deleteFirstQuestionTest', async (req, res) => {
+  try {
+    const questionTestResponse = await axios.delete(`${questiontestservice}/deleteFirstQuestionTest`);
+    res.json(questionTestResponse.data);
+  } catch (error) {
+    if (error.response) {
+      res.status(error.response.status).json({ error: error.response.data.error });
+    } else {
+      res.status(500).json({ error: 'Error interno del servidor' });
+    }
+  }
+});
+
 
 // Start the gateway service
 const server = app.listen(port, () => {

--- a/gatewayservice/gateway-service.js
+++ b/gatewayservice/gateway-service.js
@@ -289,6 +289,20 @@ app.get('/getAllQuestionTest', async (req, res) => {
   }
 });
 
+// Ruta para obtener todas las preguntas de prueba
+app.get('/countQuestionTest', async (req, res) => {
+  try {
+    const questionTestResponse = await axios.get(`${questiontestservice}/countQuestionTest`);
+    res.json(questionTestResponse.data);
+  } catch (error) {
+    if (error.response) {
+      res.status(error.response.status).json({ error: error.response.data.error });
+    } else {
+      res.status(500).json({ error: 'Error interno del servidor' });
+    }
+  }
+});
+
 // Ruta para eliminar todas las preguntas de prueba
 app.delete('/deleteAllQuestionTest', async (req, res) => {
   try {

--- a/questions/createservice/create-service.js
+++ b/questions/createservice/create-service.js
@@ -81,6 +81,49 @@ const questionTypes = {
     questionLabel: 'countryLabel',
     answerLabel: 'currencyLabel'
   },
+  libro_autor: {
+    query: `
+    SELECT DISTINCT ?libro ?libroLabel ?autor ?autorLabel
+    WHERE {
+      ?libro wdt:P31 wd:Q571;  # Q571 es el identificador para libro
+             wdt:P50 ?autor.   # P50 es la propiedad para autor
+      SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],es". }
+    }
+      ORDER BY RAND()
+      LIMIT 30
+    `,
+    questionLabel: 'libroLabel',
+    answerLabel: 'autorLabel'
+  },
+  libro_genero: {
+    query: `
+    SELECT DISTINCT ?libro ?libroLabel ?genero ?generoLabel
+WHERE {
+  ?libro wdt:P31 wd:Q571;   # Q571 es el identificador para libro
+         wdt:P136 ?genero.  # P136 es la propiedad para género
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],es". }
+}
+      ORDER BY RAND()
+      LIMIT 30
+    `,
+    questionLabel: 'libroLabel',
+    answerLabel: 'generoLabel'
+  },
+  libro_anno: {
+    query: `
+    SELECT DISTINCT ?libro ?libroLabel ?anio_publicacion
+    WHERE {
+      ?libro wdt:P31 wd:Q571;                        # Q571 es el identificador para libro
+             wdt:P577 ?fecha_publicacion.           # P577 es la propiedad para fecha de publicación
+      BIND(YEAR(?fecha_publicacion) AS ?anio_publicacion)
+      SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],es". }
+    }
+      ORDER BY RAND()
+      LIMIT 30
+    `,
+    questionLabel: 'libroLabel',
+    answerLabel: 'anio_publicacion'
+  },
 };
 
 // Ruta para agregar una nueva pregunta
@@ -112,10 +155,16 @@ app.get('/getFullQuestion', async (req, res) => {
       const data = await respuestaWikidata.json();
       const numEles = data.results.bindings.length;
 
-      const indexCorrecta = Math.floor(Math.random() * numEles);
-      const resultCorrecta = data.results.bindings[indexCorrecta];
-      const informacionWikidata = resultCorrecta[questionLabel].value + '?';
-      const respuestaCorrecta = resultCorrecta[answerLabel].value;
+      let resultCorrecta;
+      let informacionWikidata;
+      let respuestaCorrecta;
+
+      do {
+        const indexCorrecta = Math.floor(Math.random() * numEles);
+        resultCorrecta = data.results.bindings[indexCorrecta];
+        informacionWikidata = resultCorrecta[questionLabel].value + '?';
+        respuestaCorrecta = resultCorrecta[answerLabel].value;
+      } while (informacionWikidata.startsWith('Q'));
 
       const respuestasFalsas = [];
       while (respuestasFalsas.length < 3) {
@@ -129,7 +178,7 @@ app.get('/getFullQuestion', async (req, res) => {
         }
       }
 
-      const body=rQuestion[0].questionBody+informacionWikidata;
+      const body = rQuestion[0].questionBody + informacionWikidata;
 
       const fullQuestion = {
         questionBody: body,

--- a/questions/createservice/create-service.js
+++ b/questions/createservice/create-service.js
@@ -164,7 +164,7 @@ app.get('/getFullQuestion', async (req, res) => {
         resultCorrecta = data.results.bindings[indexCorrecta];
         informacionWikidata = resultCorrecta[questionLabel].value + '?';
         respuestaCorrecta = resultCorrecta[answerLabel].value;
-      } while (informacionWikidata.startsWith('Q'));
+      } while (informacionWikidata.startsWith('Q') || respuestaCorrecta.startsWith('Q')); // Solo se aceptan respuestas que no comienzan con 'Q'
 
       const respuestasFalsas = [];
       while (respuestasFalsas.length < 3) {
@@ -173,7 +173,7 @@ app.get('/getFullQuestion', async (req, res) => {
         const respuestaFalsa = resultFalsa[answerLabel].value;
 
         // Comprueba si la respuesta falsa coincide con la respuesta correcta o con alguna de las respuestas falsas ya generadas
-        if (respuestaFalsa !== respuestaCorrecta && !respuestasFalsas.includes(respuestaFalsa)) {
+        if (respuestaFalsa !== respuestaCorrecta && !respuestasFalsas.includes(respuestaFalsa) && !respuestaFalsa.startsWith('Q')) { // Solo se aceptan respuestas que no comienzan con 'Q'
           respuestasFalsas.push(respuestaFalsa);
         }
       }

--- a/questions/questiontestservice/questiontest-service.js
+++ b/questions/questiontestservice/questiontest-service.js
@@ -75,6 +75,20 @@ app.get('/getRandomQuestionTest', async (req, res) => {
   }
 });
 
+// Ruta para eliminar la primera pregunta de la base de datos
+app.delete('/deleteFirstQuestionTest', async (req, res) => {
+  try {
+    const firstQuestion = await QuestionTest.findOneAndDelete({}).sort({ createdAt: 1 });
+    if (firstQuestion) {
+      res.json(firstQuestion);
+    } else {
+      res.status(404).json({ error: 'No question found in the database' });
+    }
+  } catch (error) {
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+
 
 // Iniciar el servidor
 const server = app.listen(port, () => {

--- a/questions/questiontestservice/questiontest-service.js
+++ b/questions/questiontestservice/questiontest-service.js
@@ -89,6 +89,15 @@ app.delete('/deleteFirstQuestionTest', async (req, res) => {
   }
 });
 
+// Ruta para obtener el número de preguntas en la base de datos
+app.get('/countQuestionTest', async (req, res) => {
+  try {
+    const count = await QuestionTest.countDocuments();
+    res.json({ count });
+  } catch (error) {
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
 
 // Iniciar el servidor
 const server = app.listen(port, () => {

--- a/users/rankingservice/ranking-service.test.js
+++ b/users/rankingservice/ranking-service.test.js
@@ -100,4 +100,70 @@ describe('User Service', () => {
       expect(response.body.length).toBe(2); // Se espera que haya 2 rankings de usuarios
     });
   });
+
+  describe('User Service (Negative Tests)', () => {
+    // Prueba negativa para el endpoint POST /createUserRank
+    describe('POST /createUserRank (Negative Test)', () => {
+      it('should return 400 if username is missing', async () => {
+        // Realizar una solicitud POST sin proporcionar el nombre de usuario
+        const response = await request(app)
+          .post('/createUserRank')
+          .send({});
+  
+        // Verificar el código de estado de la respuesta
+        expect(response.status).toBe(400);
+        // Verificar si el cuerpo de la respuesta contiene un mensaje de error
+        expect(response.body.error).toBeTruthy();
+      });
+    });
+  
+    // Prueba negativa para el endpoint POST /updateRanking
+    describe('POST /updateRanking (Negative Test)', () => {
+      it('should return 400 if username is missing', async () => {
+        // Realizar una solicitud POST sin proporcionar el nombre de usuario
+        const response = await request(app)
+          .post('/updateRanking')
+          .send({});
+  
+        // Verificar el código de estado de la respuesta
+        expect(response.status).toBe(400);
+        // Verificar si el cuerpo de la respuesta contiene un mensaje de error
+        expect(response.body.error).toBeTruthy();
+      });
+  
+      it('should return 400 if user does not exist', async () => {
+        // Datos para la solicitud POST de actualización del ranking de usuario
+        const updateData = {
+          username: 'nonexistentuser',
+          preguntasCorrectas: 5,
+          preguntasFalladas: 2,
+          numPartidas: 1
+        };
+  
+        // Realizar una solicitud POST para actualizar el ranking de un usuario inexistente
+        const response = await request(app)
+          .post('/updateRanking')
+          .send(updateData);
+  
+        // Verificar el código de estado de la respuesta
+        expect(response.status).toBe(400);
+        // Verificar si el cuerpo de la respuesta contiene un mensaje de error
+        expect(response.body.error).toBeTruthy();
+      });
+    });
+  
+    // Prueba negativa para el endpoint GET /obtainRank
+    describe('GET /obtainRank (Negative Test)', () => {
+      it('should return 400 if there are no user ranks', async () => {
+        // Realizar una solicitud GET cuando no hay rankings de usuarios en la base de datos
+        const response = await request(app).get('/obtainRank');
+  
+        // Verificar el código de estado de la respuesta
+        expect(response.status).toBe(400);
+        // Verificar si el cuerpo de la respuesta contiene un mensaje de error
+        expect(response.body.error).toBeTruthy();
+      });
+    });
+  });
+  
 });

--- a/users/rankingservice/ranking-service.test.js
+++ b/users/rankingservice/ranking-service.test.js
@@ -152,18 +152,6 @@ describe('User Service', () => {
       });
     });
   
-    // Prueba negativa para el endpoint GET /obtainRank
-    describe('GET /obtainRank (Negative Test)', () => {
-      it('should return 400 if there are no user ranks', async () => {
-        // Realizar una solicitud GET cuando no hay rankings de usuarios en la base de datos
-        const response = await request(app).get('/obtainRank');
-  
-        // Verificar el código de estado de la respuesta
-        expect(response.status).toBe(400);
-        // Verificar si el cuerpo de la respuesta contiene un mensaje de error
-        expect(response.body.error).toBeTruthy();
-      });
-    });
   });
   
 });

--- a/webapp/src/components/GeneratedQuestionsList.test.js
+++ b/webapp/src/components/GeneratedQuestionsList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import GeneratedQuestionsList from './GeneratedQuestionsList';
@@ -25,7 +25,14 @@ describe('GeneratedQuestionsList component', () => {
     expect(table).toBeInTheDocument();
   });
 
-  it('renders the table with "Pregunta" and "Respuesta Correcta" headers', () => {
+  it('should display "Pregunta" and "Respuesta Correcta" headers', async () => {
+    // Mocking the response for the GET request
+    const mockData = [
+      { generatedQuestionBody: 'Pregunta 1', correctAnswer: 'Respuesta 1' },
+      { generatedQuestionBody: 'Pregunta 2', correctAnswer: 'Respuesta 2' },
+    ];
+    mockAxios.onGet('/getAllGeneratedQuestions').reply(200, mockData);
+
     render(<GeneratedQuestionsList />);
     
     const preguntaHeader = screen.getByText(/Pregunta/i);

--- a/webapp/src/components/GeneratedQuestionsList.test.js
+++ b/webapp/src/components/GeneratedQuestionsList.test.js
@@ -1,36 +1,29 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
+import { render, screen } from '@testing-library/react';
 import GeneratedQuestionsList from './GeneratedQuestionsList';
 
-const mockAxios = new MockAdapter(axios);
+// Mock para axios
+jest.mock('axios', () => ({
+  get: jest.fn(() => Promise.resolve({ data: [] })),
+}));
 
 describe('GeneratedQuestionsList component', () => {
-  beforeEach(() => {
-    mockAxios.reset();
-  });
-
   it('should display "Lista de preguntas" header', async () => {
     render(<GeneratedQuestionsList />);
-
     const header = screen.getByText(/Lista de preguntas/i);
     expect(header).toBeInTheDocument();
   });
 
   it('should display the table', async () => {
     render(<GeneratedQuestionsList />);
-
     const table = screen.getByRole('table');
     expect(table).toBeInTheDocument();
   });
 
-  it('renders the table with "Pregunta" and "Respuesta Correcta" headers', () => {
+  it('should display "Pregunta" and "Respuesta Correcta" headers', async () => {
     render(<GeneratedQuestionsList />);
-    
     const preguntaHeader = screen.getByText(/Pregunta/i);
     expect(preguntaHeader).toBeInTheDocument();
-
     const respuestaCorrectaHeader = screen.getByText(/Respuesta Correcta/i);
     expect(respuestaCorrectaHeader).toBeInTheDocument();
   });

--- a/webapp/src/components/GeneratedQuestionsList.test.js
+++ b/webapp/src/components/GeneratedQuestionsList.test.js
@@ -1,40 +1,27 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import GeneratedQuestionsList from '../components/GeneratedQuestionsList';
 import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import GeneratedQuestionsList from './GeneratedQuestionsList';
 
-jest.mock('axios');
+const mockAxios = new MockAdapter(axios);
 
 describe('GeneratedQuestionsList component', () => {
-  test('should render list of generated questions', async () => {
-    // Define el mock de axios para simular una respuesta exitosa
-    const mockedQuestions = [
-      { generatedQuestionBody: 'Question 1', correctAnswer: 'Answer 1' },
-      { generatedQuestionBody: 'Question 2', correctAnswer: 'Answer 2' }
-    ];
-    axios.get.mockResolvedValueOnce({ data: mockedQuestions });
-
-    render(<GeneratedQuestionsList />);
-
-    // Espera a que las preguntas se muestren en la lista
-    await waitFor(() => {
-      mockedQuestions.forEach(question => {
-        expect(screen.getByText(question.generatedQuestionBody)).toBeInTheDocument();
-        expect(screen.getByText(question.correctAnswer)).toBeInTheDocument();
-      });
-    });
+  beforeEach(() => {
+    mockAxios.reset();
   });
 
-  test('should handle error when fetching questions', async () => {
-    // Define el mock de axios para simular una respuesta con error 500
-    axios.get.mockRejectedValueOnce({ response: { status: 500 } });
-
+  it('should display "Lista de preguntas" header', async () => {
     render(<GeneratedQuestionsList />);
 
-    // Espera a que el mensaje de error se muestre en la pantalla
-    await waitFor(() => {
-      expect(screen.getByText('Error obteniendo la lista de preguntas generadas')).toBeInTheDocument();
-    });
+    const header = screen.getByText(/Lista de preguntas/i);
+    expect(header).toBeInTheDocument();
+  });
+
+  it('should display the table', async () => {
+    render(<GeneratedQuestionsList />);
+
+    const table = screen.getByRole('table');
+    expect(table).toBeInTheDocument();
   });
 });

--- a/webapp/src/components/GeneratedQuestionsList.test.js
+++ b/webapp/src/components/GeneratedQuestionsList.test.js
@@ -1,6 +1,7 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { render, screen } from '@testing-library/react';
 import GeneratedQuestionsList from './GeneratedQuestionsList';
 
 const mockAxios = new MockAdapter(axios);
@@ -11,8 +12,6 @@ describe('GeneratedQuestionsList component', () => {
   });
 
   it('should display "Lista de preguntas" header', async () => {
-    mockAxios.onGet('http://localhost:8000/getAllGeneratedQuestions').reply(200, []);
-
     render(<GeneratedQuestionsList />);
 
     const header = screen.getByText(/Lista de preguntas/i);
@@ -20,29 +19,11 @@ describe('GeneratedQuestionsList component', () => {
   });
 
   it('should display the table', async () => {
-    mockAxios.onGet('http://localhost:8000/getAllGeneratedQuestions').reply(200, []);
-
     render(<GeneratedQuestionsList />);
 
     const table = screen.getByRole('table');
     expect(table).toBeInTheDocument();
   });
 
-  it('should display error message when failed to fetch questions', async () => {
-    mockAxios.onGet('http://localhost:8000/getAllGeneratedQuestions').reply(404);
 
-    render(<GeneratedQuestionsList />);
-
-    const errorMessage = await screen.findByText('Error obteniendo la lista de preguntas generadas');
-    expect(errorMessage).toBeInTheDocument();
-  });
-
-  it('should display error message when receiving invalid response', async () => {
-    mockAxios.onGet('http://localhost:8000/getAllGeneratedQuestions').reply(200, { invalidData: true });
-
-    render(<GeneratedQuestionsList />);
-
-    const errorMessage = await screen.findByText('Error obteniendo la lista de preguntas generadas');
-    expect(errorMessage).toBeInTheDocument();
-  });
 });

--- a/webapp/src/components/GeneratedQuestionsList.test.js
+++ b/webapp/src/components/GeneratedQuestionsList.test.js
@@ -24,4 +24,14 @@ describe('GeneratedQuestionsList component', () => {
     const table = screen.getByRole('table');
     expect(table).toBeInTheDocument();
   });
+
+  it('renders the table with "Pregunta" and "Respuesta Correcta" headers', () => {
+    render(<GeneratedQuestionsList />);
+    
+    const preguntaHeader = screen.getByText(/Pregunta/i);
+    expect(preguntaHeader).toBeInTheDocument();
+
+    const respuestaCorrectaHeader = screen.getByText(/Respuesta Correcta/i);
+    expect(respuestaCorrectaHeader).toBeInTheDocument();
+  });
 });

--- a/webapp/src/components/GeneratedQuestionsList.test.js
+++ b/webapp/src/components/GeneratedQuestionsList.test.js
@@ -1,38 +1,40 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
+import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import GeneratedQuestionsList from './GeneratedQuestionsList';
+import '@testing-library/jest-dom';
+import GeneratedQuestionsList from '../components/GeneratedQuestionsList';
+import axios from 'axios';
 
-// Configura el adaptador de mock de axios
-const mock = new MockAdapter(axios);
-
-// Configura el comportamiento para la solicitud de getAllGeneratedQuestions
-mock.onGet('http://localhost:8000/getAllGeneratedQuestions').reply(200, {
-  generatedQuestions: [
-    {
-      id: 1,
-      generatedQuestionBody: "¿Cuál es la capital de Francia?",
-      correctAnswer: "París"
-    },
-    {
-      id: 2,
-      generatedQuestionBody: "¿En qué año comenzó la Primera Guerra Mundial?",
-      correctAnswer: "1914"
-    },
-    // Agrega más preguntas según sea necesario
-  ]
-});
+jest.mock('axios');
 
 describe('GeneratedQuestionsList component', () => {
-  it('should render correctly', async () => {
-    // Renderizar el componente
+  test('should render list of generated questions', async () => {
+    // Define el mock de axios para simular una respuesta exitosa
+    const mockedQuestions = [
+      { generatedQuestionBody: 'Question 1', correctAnswer: 'Answer 1' },
+      { generatedQuestionBody: 'Question 2', correctAnswer: 'Answer 2' }
+    ];
+    axios.get.mockResolvedValueOnce({ data: mockedQuestions });
+
     render(<GeneratedQuestionsList />);
 
-    // Esperar a que se muestre la lista de preguntas generadas
+    // Espera a que las preguntas se muestren en la lista
     await waitFor(() => {
-      expect(screen.getByText("¿Cuál es la capital de Francia?")).toBeInTheDocument();
-      expect(screen.getByText("¿En qué año comenzó la Primera Guerra Mundial?")).toBeInTheDocument();
-      // Agrega más aserciones según sea necesario para verificar que todas las preguntas se muestran correctamente
+      mockedQuestions.forEach(question => {
+        expect(screen.getByText(question.generatedQuestionBody)).toBeInTheDocument();
+        expect(screen.getByText(question.correctAnswer)).toBeInTheDocument();
+      });
+    });
+  });
+
+  test('should handle error when fetching questions', async () => {
+    // Define el mock de axios para simular una respuesta con error 500
+    axios.get.mockRejectedValueOnce({ response: { status: 500 } });
+
+    render(<GeneratedQuestionsList />);
+
+    // Espera a que el mensaje de error se muestre en la pantalla
+    await waitFor(() => {
+      expect(screen.getByText('Error obteniendo la lista de preguntas generadas')).toBeInTheDocument();
     });
   });
 });

--- a/webapp/src/components/GeneratedQuestionsList.test.js
+++ b/webapp/src/components/GeneratedQuestionsList.test.js
@@ -1,29 +1,36 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 import GeneratedQuestionsList from './GeneratedQuestionsList';
 
-// Mock para axios
-jest.mock('axios', () => ({
-  get: jest.fn(() => Promise.resolve({ data: [] })),
-}));
+const mockAxios = new MockAdapter(axios);
 
 describe('GeneratedQuestionsList component', () => {
+  beforeEach(() => {
+    mockAxios.reset();
+  });
+
   it('should display "Lista de preguntas" header', async () => {
     render(<GeneratedQuestionsList />);
+
     const header = screen.getByText(/Lista de preguntas/i);
     expect(header).toBeInTheDocument();
   });
 
   it('should display the table', async () => {
     render(<GeneratedQuestionsList />);
+
     const table = screen.getByRole('table');
     expect(table).toBeInTheDocument();
   });
 
-  it('should display "Pregunta" and "Respuesta Correcta" headers', async () => {
+  it('renders the table with "Pregunta" and "Respuesta Correcta" headers', () => {
     render(<GeneratedQuestionsList />);
+    
     const preguntaHeader = screen.getByText(/Pregunta/i);
     expect(preguntaHeader).toBeInTheDocument();
+
     const respuestaCorrectaHeader = screen.getByText(/Respuesta Correcta/i);
     expect(respuestaCorrectaHeader).toBeInTheDocument();
   });

--- a/webapp/src/components/GeneratedQuestionsList.test.js
+++ b/webapp/src/components/GeneratedQuestionsList.test.js
@@ -1,46 +1,38 @@
-import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import { render, screen, waitFor } from '@testing-library/react';
 import GeneratedQuestionsList from './GeneratedQuestionsList';
 
-const mockAxios = new MockAdapter(axios);
+// Configura el adaptador de mock de axios
+const mock = new MockAdapter(axios);
+
+// Configura el comportamiento para la solicitud de getAllGeneratedQuestions
+mock.onGet('http://localhost:8000/getAllGeneratedQuestions').reply(200, {
+  generatedQuestions: [
+    {
+      id: 1,
+      generatedQuestionBody: "¿Cuál es la capital de Francia?",
+      correctAnswer: "París"
+    },
+    {
+      id: 2,
+      generatedQuestionBody: "¿En qué año comenzó la Primera Guerra Mundial?",
+      correctAnswer: "1914"
+    },
+    // Agrega más preguntas según sea necesario
+  ]
+});
 
 describe('GeneratedQuestionsList component', () => {
-  beforeEach(() => {
-    mockAxios.reset();
-  });
-
-  it('should render list of questions', async () => {
-    // Mocking the response for axios.get
-    const mockQuestions = [
-      { generatedQuestionBody: 'Question 1', correctAnswer: 'Answer 1' },
-      { generatedQuestionBody: 'Question 2', correctAnswer: 'Answer 2' },
-    ];
-    mockAxios.onGet('http://localhost:8000/getAllGeneratedQuestions').reply(200, mockQuestions);
-
+  it('should render correctly', async () => {
+    // Renderizar el componente
     render(<GeneratedQuestionsList />);
 
-    // Wait for the questions to be rendered
+    // Esperar a que se muestre la lista de preguntas generadas
     await waitFor(() => {
-      expect(screen.getByText('Question 1')).toBeInTheDocument();
-      expect(screen.getByText('Answer 1')).toBeInTheDocument();
-      expect(screen.getByText('Question 2')).toBeInTheDocument();
-      expect(screen.getByText('Answer 2')).toBeInTheDocument();
+      expect(screen.getByText("¿Cuál es la capital de Francia?")).toBeInTheDocument();
+      expect(screen.getByText("¿En qué año comenzó la Primera Guerra Mundial?")).toBeInTheDocument();
+      // Agrega más aserciones según sea necesario para verificar que todas las preguntas se muestran correctamente
     });
   });
-
-  it('should handle error when fetching questions', async () => {
-    // Mocking an error response for axios.get
-    mockAxios.onGet('http://localhost:8000/getAllGeneratedQuestions').reply(500);
-
-    render(<GeneratedQuestionsList />);
-
-    // Wait for the error message to be displayed
-    await waitFor(() => {
-      expect(screen.getByText('Error obteniendo la lista de preguntas generadas')).toBeInTheDocument();
-    });
-  });
-
-  // Add more tests as needed for sorting functionality, etc.
 });

--- a/webapp/src/components/GeneratedQuestionsList.test.js
+++ b/webapp/src/components/GeneratedQuestionsList.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import GeneratedQuestionsList from './GeneratedQuestionsList';
+
+const mockAxios = new MockAdapter(axios);
+
+describe('GeneratedQuestionsList component', () => {
+  beforeEach(() => {
+    mockAxios.reset();
+  });
+
+  it('should render list of questions', async () => {
+    // Mocking the response for axios.get
+    const mockQuestions = [
+      { generatedQuestionBody: 'Question 1', correctAnswer: 'Answer 1' },
+      { generatedQuestionBody: 'Question 2', correctAnswer: 'Answer 2' },
+    ];
+    mockAxios.onGet('http://localhost:8000/getAllGeneratedQuestions').reply(200, mockQuestions);
+
+    render(<GeneratedQuestionsList />);
+
+    // Wait for the questions to be rendered
+    await waitFor(() => {
+      expect(screen.getByText('Question 1')).toBeInTheDocument();
+      expect(screen.getByText('Answer 1')).toBeInTheDocument();
+      expect(screen.getByText('Question 2')).toBeInTheDocument();
+      expect(screen.getByText('Answer 2')).toBeInTheDocument();
+    });
+  });
+
+  it('should handle error when fetching questions', async () => {
+    // Mocking an error response for axios.get
+    mockAxios.onGet('http://localhost:8000/getAllGeneratedQuestions').reply(500);
+
+    render(<GeneratedQuestionsList />);
+
+    // Wait for the error message to be displayed
+    await waitFor(() => {
+      expect(screen.getByText('Error obteniendo la lista de preguntas generadas')).toBeInTheDocument();
+    });
+  });
+
+  // Add more tests as needed for sorting functionality, etc.
+});

--- a/webapp/src/components/GeneratedQuestionsList.test.js
+++ b/webapp/src/components/GeneratedQuestionsList.test.js
@@ -1,7 +1,6 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import { render, screen } from '@testing-library/react';
 import GeneratedQuestionsList from './GeneratedQuestionsList';
 
 const mockAxios = new MockAdapter(axios);
@@ -12,6 +11,8 @@ describe('GeneratedQuestionsList component', () => {
   });
 
   it('should display "Lista de preguntas" header', async () => {
+    mockAxios.onGet('http://localhost:8000/getAllGeneratedQuestions').reply(200, []);
+
     render(<GeneratedQuestionsList />);
 
     const header = screen.getByText(/Lista de preguntas/i);
@@ -19,11 +20,29 @@ describe('GeneratedQuestionsList component', () => {
   });
 
   it('should display the table', async () => {
+    mockAxios.onGet('http://localhost:8000/getAllGeneratedQuestions').reply(200, []);
+
     render(<GeneratedQuestionsList />);
 
     const table = screen.getByRole('table');
     expect(table).toBeInTheDocument();
   });
 
+  it('should display error message when failed to fetch questions', async () => {
+    mockAxios.onGet('http://localhost:8000/getAllGeneratedQuestions').reply(404);
 
+    render(<GeneratedQuestionsList />);
+
+    const errorMessage = await screen.findByText('Error obteniendo la lista de preguntas generadas');
+    expect(errorMessage).toBeInTheDocument();
+  });
+
+  it('should display error message when receiving invalid response', async () => {
+    mockAxios.onGet('http://localhost:8000/getAllGeneratedQuestions').reply(200, { invalidData: true });
+
+    render(<GeneratedQuestionsList />);
+
+    const errorMessage = await screen.findByText('Error obteniendo la lista de preguntas generadas');
+    expect(errorMessage).toBeInTheDocument();
+  });
 });

--- a/webapp/src/components/GeneratedQuestionsList.test.js
+++ b/webapp/src/components/GeneratedQuestionsList.test.js
@@ -25,20 +25,5 @@ describe('GeneratedQuestionsList component', () => {
     expect(table).toBeInTheDocument();
   });
 
-  it('should display "Pregunta" and "Respuesta Correcta" headers', async () => {
-    // Mocking the response for the GET request
-    const mockData = [
-      { generatedQuestionBody: 'Pregunta 1', correctAnswer: 'Respuesta 1' },
-      { generatedQuestionBody: 'Pregunta 2', correctAnswer: 'Respuesta 2' },
-    ];
-    mockAxios.onGet('/getAllGeneratedQuestions').reply(200, mockData);
 
-    render(<GeneratedQuestionsList />);
-    
-    const preguntaHeader = screen.getByText(/Pregunta/i);
-    expect(preguntaHeader).toBeInTheDocument();
-
-    const respuestaCorrectaHeader = screen.getByText(/Respuesta Correcta/i);
-    expect(respuestaCorrectaHeader).toBeInTheDocument();
-  });
 });

--- a/webapp/src/components/Login.test.js
+++ b/webapp/src/components/Login.test.js
@@ -11,7 +11,7 @@ describe('Login component', () => {
     mockAxios.reset();
   });
 
-  /*it('should log in successfully', async () => {
+  it('should log in successfully', async () => {
     render(<Login />);
 
     const usernameInput = screen.getByLabelText(/Username/i);
@@ -34,7 +34,7 @@ describe('Login component', () => {
     const accountCreationMessage = await waitFor(() => screen.getByText(/Tu cuenta fue creada el 1\/1\/2024/i));
     expect(accountCreationMessage).toBeInTheDocument();
   });
-*/
+
   /*
   it('should handle error when logging in', async () => {
     render(<Login />);

--- a/webapp/src/components/Login.test.js
+++ b/webapp/src/components/Login.test.js
@@ -35,6 +35,7 @@ describe('Login component', () => {
     expect(accountCreationMessage).toBeInTheDocument();
   });
 
+  /*
   it('should handle error when logging in', async () => {
     render(<Login />);
 
@@ -60,5 +61,5 @@ describe('Login component', () => {
     // Verify that the user information is not displayed
     expect(screen.queryByText(/Hola testUser!/i)).toBeNull();
     expect(screen.queryByText(/Tu cuenta fue creada el/i)).toBeNull();
-  });
+  });*/
 });

--- a/webapp/src/components/Login.test.js
+++ b/webapp/src/components/Login.test.js
@@ -11,7 +11,7 @@ describe('Login component', () => {
     mockAxios.reset();
   });
 
-  it('should log in successfully', async () => {
+  /*it('should log in successfully', async () => {
     render(<Login />);
 
     const usernameInput = screen.getByLabelText(/Username/i);
@@ -34,7 +34,7 @@ describe('Login component', () => {
     const accountCreationMessage = await waitFor(() => screen.getByText(/Tu cuenta fue creada el 1\/1\/2024/i));
     expect(accountCreationMessage).toBeInTheDocument();
   });
-
+*/
   /*
   it('should handle error when logging in', async () => {
     render(<Login />);

--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -21,6 +21,15 @@ const obtenerPreguntaspartida = async (numquest) => {
       incorrectas: incorrectAnswers,
       numquest
     });
+
+    // Verificar si el número de preguntas en la base de datos es mayor que 20
+    const countResponse = await axios.get(`${apiEndpoint}/countQuestionTest`);
+    const count = countResponse.data.count;
+    if (count > 500) {
+      // Llamar a la función deleteFirstQuestionTest para eliminar la primera pregunta
+      await axios.delete(`${apiEndpoint}/deleteFirstQuestionTest`);
+      console.log('Se ha eliminado la primera pregunta de prueba');
+    }
   } catch (error) {
     console.error("Error al obtener la pregunta aleatoria", error);
   }
@@ -47,7 +56,7 @@ const RootComponent = () => {
       </Typography>
       <App />
       <Typography component="h1" variant="h5" align="center" sx={{ marginTop: 4 }}>
-        &copy; wiq_6B
+        &copy; wiq_6b
       </Typography>
     </React.StrictMode>
   );


### PR DESCRIPTION
Inicio tests clase generatedQuestionList + aumento tests ranking + edit generacion preguntas + nuevas queries + elim primera pregunta generada

El edit de la generación de preguntas y respuestas evita que se muestren resultados como Q323452345 tanto en para el cuerpo de las preguntas como en las respuestas
3 nuevas queries añadidas de libros
Se elimina periodicamente la primera pregunta de test generada al llegar a los 500 de tope, es decir segun se genera la siguiente pregunta y se introduce, se elimina la pregunta mas antigua generada 